### PR TITLE
Remove request_unixsocket dependency

### DIFF
--- a/jupyter_server/tests/services/nbconvert/test_api.py
+++ b/jupyter_server/tests/services/nbconvert/test_api.py
@@ -4,7 +4,11 @@ import json
 async def test_list_formats(jp_fetch):
     r = await jp_fetch("api", "nbconvert", method="GET")
     formats = json.loads(r.body.decode())
+    # Verify the type of the response.
     assert isinstance(formats, dict)
-    assert "python" in formats
-    assert "html" in formats
-    assert formats["python"]["output_mimetype"] == "text/x-python"
+    # Verify that all returned formats have an
+    # output mimetype defined.
+    required_keys_present = []
+    for name, data in formats.items():
+        required_keys_present.append("output_mimetype" in data)
+    assert all(required_keys_present), "All returned formats must have a `output_mimetype` key."

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     prometheus_client
     anyio>=3.1.0,<4
     websocket-client
-    requests-unixsocket
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Unix socket support was ported from Notebook which has a test that uses `requests_unixsocket` to test the functionality because we had to update the test to use a lazy import so we could remove this dependency on Windows.
The tests within jupyter_server are quite different and, it appears based on the successful tests, that this dependency isn't required at all.  This pull request removes the dependency.