### PR TITLE
Introduce ServerKernelManager class

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -666,7 +666,7 @@ class AsyncMappingKernelManager(MappingKernelManager, AsyncMultiKernelManager):
         km_class = import_item(km_class_value)
         if not issubclass(km_class, ServerKernelManager):
             warnings.warn(
-                f"KernelManager class '{km_class}' is not a subclass of `ServerKernelManager`.  Custom "
+                f"KernelManager class '{km_class}' is not a subclass of 'ServerKernelManager'.  Custom "
                 "KernelManager classes should derive from 'ServerKernelManager' beginning with jupyter-server 2.0 "
                 "or risk missing functionality.  Continuing...",
                 FutureWarning,

--- a/tests/services/kernels/test_config.py
+++ b/tests/services/kernels/test_config.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from traitlets.config import Config
 
@@ -21,3 +23,11 @@ def test_async_kernel_manager(jp_configurable_serverapp):
     ]
     app = jp_configurable_serverapp(argv=argv)
     assert isinstance(app.kernel_manager, AsyncMappingKernelManager)
+
+
+def test_not_server_kernel_manager(jp_configurable_serverapp):
+    argv = [
+        "--AsyncMappingKernelManager.kernel_manager_class=jupyter_client.ioloop.manager.AsyncIOLoopKernelManager"
+    ]
+    with pytest.warns(FutureWarning, match="is not a subclass of 'ServerKernelManager'"):
+        jp_configurable_serverapp(argv=argv)


### PR DESCRIPTION
Per this [comment/response](https://github.com/jupyter-server/jupyter_server/issues/789#issuecomment-1325453486), this pull request introduces a `ServerKernelManager` class which is instantiated by default within the `AsyncMappingKernelManager` for each managed instance.  Currently, `ServerKernelManager` derives from jupyter_client's `AsyncIOLoopKernelManager`, thereby preserving existing functionality.

Introducing this class allows the Server to use this implementation to provide server-specific functionality like kernel-based events, the potential for highly available kernels, etc., and re-enforces the notion that the `KernelManager` class (and corresponding functionality) is the purview of the _application_.  

Applications bringing their own subclass of `AsyncIOLoopKernelManager` should update their implementations to derive from `ServerKernelManager` or risk missing functionality that ultimately is associated with `ServerKernelManager`.

With this PR the _activity-tracking_ attributes that were previously patched onto the current instance are formally defined traits.  As a result, the `execution_state`'s initial value is _"initializing"_, which will be set to _"starting"_ upon the completion of the `start_kernel()` method.  If this complicates state management too much, we can have the initial state be _"starting"_, but I felt "initializing" was more correct.

Note that this PR does NOT introduce a similarly named class relative to `MappingKernelManager`.  This simplifies support and serves as an impetus for applications/server extensions to switch to using the async kernel management.