### PR TITLE
Ensure content-type properly reflects gateway kernelspec resources

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -773,7 +773,9 @@ class APIHandler(JupyterHandler):
     def finish(self, *args, **kwargs):
         """Finish an API response."""
         self.update_api_activity()
-        self.set_header("Content-Type", "application/json")
+        # Allow caller to indicate content-type...
+        set_content_type = kwargs.pop("set_content_type", "application/json")
+        self.set_header("Content-Type", set_content_type)
         return super().finish(*args, **kwargs)
 
     def options(self, *args, **kwargs):

--- a/jupyter_server/gateway/handlers.py
+++ b/jupyter_server/gateway/handlers.py
@@ -6,7 +6,7 @@ import logging
 import mimetypes
 import os
 import random
-from typing import cast
+from typing import Optional, cast
 
 from jupyter_client.session import Session
 from tornado import web
@@ -281,6 +281,7 @@ class GatewayResourceHandler(APIHandler):
     @web.authenticated
     async def get(self, kernel_name, path, include_body=True):
         """Get a gateway resource by name and path."""
+        mimetype: Optional[str] = None
         ksm = self.kernel_spec_manager
         kernel_spec_res = await ksm.get_kernel_spec_resource(kernel_name, path)
         if kernel_spec_res is None:
@@ -290,8 +291,7 @@ class GatewayResourceHandler(APIHandler):
             )
         else:
             mimetype = mimetypes.guess_type(path)[0] or "text/plain"
-            self.set_header("Content-Type", mimetype)
-        self.finish(kernel_spec_res)
+        self.finish(kernel_spec_res, set_content_type=mimetype)
 
 
 from ..services.kernels.handlers import _kernel_id_regex

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -422,9 +422,10 @@ async def test_gateway_get_named_kernelspec(init_gateway, jp_fetch):
         kspec_foo = json.loads(r.body.decode("utf-8"))
         assert kspec_foo.get("name") == "kspec_foo"
 
-        r = await jp_fetch("kernelspecs", "kspec_foo", "hi", method="GET")
+        r = await jp_fetch("kernelspecs", "kspec_foo", "logo-64x64.png", method="GET")
         assert r.code == 200
         assert r.body == b"foo"
+        assert r.headers["content-type"] == "image/png"
 
         with pytest.raises(tornado.httpclient.HTTPClientError) as e:
             await jp_fetch("api", "kernelspecs", "no_such_spec", method="GET")


### PR DESCRIPTION
The `APIHandler.finish()` method unconditionally overrides the header's `Content-type` to `application/json` despite the `GatewayResourceHandler` setting it to a mime-type corresponding to the resource's extension.

This pull request enables the caller to indicate the `ContentType` that should be set into the header in `APIHandler.finish()` where `application/json` is the default if no content type is specified.